### PR TITLE
Add: Map list auto update

### DIFF
--- a/scripting/autogen_maplist.sp
+++ b/scripting/autogen_maplist.sp
@@ -8,15 +8,15 @@
 #define INCLUDE_WS_MAPS 1
 #define ABC_SORT 1
 
-ArrayList g_hMaps;
-ArrayList g_hDeleteMaps;
-ArrayList g_hSortMaps;
+ArrayList 	g_hMaps, 
+			g_hDeleteMaps,
+			g_hSortMaps;
 
 public Plugin myinfo =
 {
 	name        = 	"Auto Generation MapList",
 	author      = 	"FIVE",
-	version     = 	"1.0",
+	version     = 	"1.0.0",
 	url         = 	"Source: http://hlmod.ru | Support: https://discord.gg/ajW69wN"
 };
 
@@ -29,14 +29,14 @@ public void OnPluginStart()
 	RegServerCmd("sm_update_maplist", cmd_Update);
 }
 
-public void OnServerLoad()
+public void OnMapStart()
 {
 	fUpdateMapList();
 }
 
 Action cmd_Update(int iArgs)
 {
-	OnServerLoad();
+	fUpdateMapList();
     return Plugin_Handled;
 }
 

--- a/scripting/autogen_maplist.sp
+++ b/scripting/autogen_maplist.sp
@@ -37,6 +37,7 @@ public void OnServerLoad()
 Action cmd_Update(int iArgs)
 {
 	OnServerLoad();
+    return Plugin_Handled;
 }
 
 void fUpdateMapList()

--- a/scripting/autogen_maplist.sp
+++ b/scripting/autogen_maplist.sp
@@ -27,13 +27,16 @@ public void OnPluginStart()
 	g_hSortMaps = new ArrayList(ByteCountToCells(64));
 
 	RegServerCmd("sm_update_maplist", cmd_Update);
+}
 
+public void OnServerLoad()
+{
 	fUpdateMapList();
 }
 
 Action cmd_Update(int iArgs)
 {
-	fUpdateMapList();
+	OnServerLoad();
 }
 
 void fUpdateMapList()

--- a/scripting/autogen_maplist.sp
+++ b/scripting/autogen_maplist.sp
@@ -29,7 +29,7 @@ public void OnPluginStart()
 	RegServerCmd("sm_update_maplist", cmd_Update);
 }
 
-public void OnMapStart()
+public void OnServerLoad()
 {
 	fUpdateMapList();
 }


### PR DESCRIPTION
- Убирает необходимость в использовании команды при обновлении маппула
- Исключает возможную ошибку при запуске сервера, если `mapcycle` & `maplist` не существует
- Исключает загрузку стд карт после обновления сервера в ротатор.